### PR TITLE
Fix: 결제 완료 페이지 임의 수정

### DIFF
--- a/pybo/views/orders.py
+++ b/pybo/views/orders.py
@@ -69,7 +69,8 @@ def payment(user_id):
         
     elif request.method == 'POST':
 
-        cursor.execute("SELECT user_id, u.wallet_id, w.rest from wallet as w join users as u where user_id='{}';".format(user_id))
+        cursor.execute('''SELECT user_id, u.wallet_id, w.rest from wallet as w 
+                            join users as u where user_id='{}';'''.format(user_id))
         wallet = cursor.fetchone()
 
         user_id = wallet[0]
@@ -78,19 +79,14 @@ def payment(user_id):
 
         sum_total = int(float(request.form['sum_total']))
 
-        print(rest)
-        print(sum_total)
-
             # 총 금액과 지갑 비교
         if sum_total <= rest:
             afterest = rest - sum_total
             cursor.execute("update wallet set rest='{}' where wallet_id = {};".format(afterest, wallet_id))
             db.commit()
-            flash('결제가 완료되었습니다!')
-            return render_template('orders.html', user_id=user_id), 200
+            # 주문 내역 페이지로 이동 (현재는 우선 mypage로 이동)
+            return '''<script>alert('결제가 완료되었습니다!');
+                    window.location.href = '{0}';</script>'''.format(url_for('mypage.info_check', user_id=user_id))
         else:
-            flash('잔액이 부족합니다.')
-            return render_template('orders.html', user_id=user_id), 200
-
-        
-
+            return '''<script>alert('잔액이 부족합니다. 지갑을 충전하세요!');
+                    window.location.href = '{0}';</script>'''.format(url_for('mypage.info_check', user_id=user_id))


### PR DESCRIPTION
## :: 작업 내용
- [ ] 기능 추가
- [ ] 리뷰 반영
- [ ] 리팩토링
- [x] 버그 수정
- [ ] 컨벤션 수정
- [ ] 테스트

## :: 구현 목표
- 결제 버튼 클릭 후 팝업 창 안내가 끝나면 기존 페이지에 redirect 되는 부분 수정
- 주문 내역을 확인할 수 있도록 결제 완료 시 mypage로 이동

## :: 구현 사항 설명
- 결제 성공/실패 시 팝업 창으로 안내 후 mypage로 리턴
- 추후 결제 성공 시 주문 내역 페이지로 이동할 계획
![결제 후 마이페이지 리턴](https://user-images.githubusercontent.com/48422575/236155723-f8ba9326-0959-4a5f-8c54-e9196a8ed359.gif)

## :: 특이 사항
-  현재 결제 페이지에서는 wallet 테이블의 rest 차감만 이루어짐 
- 충전은 mypage에서 or 최초 회원가입 시 default로 일정 금액 생성